### PR TITLE
Update README and setup.py for builds on macOS and Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,31 +3,49 @@
 
 A python wrapper around libprio.
 
-This library provides low-level bindings to the reference C implementation of the [Prio system](https://github.com/mozilla/libprio) and a high-level Python interface.
+This library provides low-level bindings to the reference C implementation of
+the [Prio system](https://github.com/mozilla/libprio) and a high-level Python
+interface.
 
 
 ## Build
 
+The `libprio` submodule must be initialized before building. Run the following
+command to initialize the modules.
+
+```bash
+$ git submodule update --init --recursive
+```
+
 ### Docker (recommended)
 
-This project contains a pre-configured build and test environment through docker.
+This project contains a pre-configured build and test environment through
+docker.
 
-```
+```bash
 $ docker build -t prio .
 $ docker run -it prio
 ```
-This will build the package and run the tests.
-You can mount your working directory and shell into the container for development work.
+This will build the package and run the tests. You can mount your working
+directory and shell into the container for development work.
 
-```
+```bash
 $ docker run -v `pwd`:/app -it prio bash
 ```
 
 ### Local
 
-Refer to the Dockerfile and the `libprio` submodule for dependencies.
+Refer to the Dockerfile and the `libprio` submodule for dependencies. If you are
+running on macOS, you will need need to export the following flags for linking and
+including the necessary nss and nspr dependencies.
 
+```bash
+$ brew install nss nspr scons msgpack swig
+$ export LINKFLAGS="-L/usr/local/opt/nss/lib"
+$ export CPPFLAGS="-I/usr/local/opt/nss/include/nss -I/usr/local/opt/nspr/include/nspr"
 ```
+
+```bash
 $ make
 $ make test
 ```

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The `libprio` submodule must be initialized before building. Run the following
 command to initialize the modules.
 
 ```bash
-$ git submodule update --init --recursive
+git submodule update --init
 ```
 
 ### Docker (recommended)
@@ -23,14 +23,14 @@ This project contains a pre-configured build and test environment through
 docker.
 
 ```bash
-$ docker build -t prio .
-$ docker run -it prio
+docker build -t prio .
+docker run -it prio
 ```
 This will build the package and run the tests. You can mount your working
 directory and shell into the container for development work.
 
 ```bash
-$ docker run -v `pwd`:/app -it prio bash
+docker run -v `pwd`:/app -it prio bash
 ```
 
 ### Local
@@ -40,14 +40,14 @@ running on macOS, you will need need to export the following flags for linking a
 including the necessary nss and nspr dependencies.
 
 ```bash
-$ brew install nss nspr scons msgpack swig
-$ export LINKFLAGS="-L/usr/local/opt/nss/lib"
-$ export CPPFLAGS="-I/usr/local/opt/nss/include/nss -I/usr/local/opt/nspr/include/nspr"
+brew install nss nspr scons msgpack swig
+export LINKFLAGS="-L/usr/local/opt/nss/lib"
+export CPPFLAGS="-I/usr/local/opt/nss/include/nss -I/usr/local/opt/nspr/include/nspr"
 ```
 
 ```bash
-$ make
-$ make test
+make
+make test
 ```
 
 ### Notes
@@ -59,14 +59,14 @@ This is required for the python foreign-function interface.
 ## Test
 
 ```bash
-$ docker build -t prio . && docker run -it prio
+docker build -t prio . && docker run -it prio
 ```
 You can avoid rebuilds by mounting your working directory and testing directly within the container.
 
 If you want to avoid the Makefile for tests, the project uses pytest.
 ```bash
-$ pipenv sync --dev
-$ pipenv run pytest
+pipenv sync --dev
+pipenv run pytest
 ```
 
 ## Running examples

--- a/setup.py
+++ b/setup.py
@@ -6,33 +6,47 @@ import setuptools
 from distutils.core import setup, Extension
 from glob import glob
 from os import path
+from sys import platform
 
 
 this_directory = path.abspath(path.dirname(__file__))
-with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
+with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
+
+
+# Add platform specific settings for building the extension module
+if platform == "darwin":
+    # macOS
+    library_dirs = ["/usr/local/opt/nss/lib"]
+    include_dirs = [
+        "/usr/local/opt/nss/include/nss",
+        "/usr/local/opt/nspr/include/nspr",
+    ]
+    libraries = ["nss", "nspr4"]
+else:
+    # Fedora
+    library_dirs = []
+    include_dirs = ["/usr/include/nspr", "/usr/include/nss"]
+    libraries = ["nss3", "nspr4"]
 
 
 extension_mod = Extension(
     "_libprio",
     ["libprio_wrap.c"],
-    library_dirs=[
-        "libprio/build/prio",
-        "libprio/build/mpi",
-    ],
-    include_dirs=["/usr/include/nspr", "/usr/include/nss"],
-    libraries=["mprio", "mpi", "nss3", "nspr4", "msgpackc"],
+    library_dirs=["libprio/build/prio", "libprio/build/mpi"] + library_dirs,
+    include_dirs=include_dirs,
+    libraries=["mprio", "mpi", "msgpackc"] + libraries,
 )
 
 setup(
     name="prio",
-    version = "0.2",
-    description = "An interface to libprio",
-    long_description = long_description,
-    long_description_content_type='text/markdown',
-    author = "Anthony Miyaguchi",
-    author_email = "amiyaguchi@mozilla.com",
-    url = "https://github.com/acmiyaguchi/python-libprio",
-    packages = ["prio"],
+    version="0.2",
+    description="An interface to libprio",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    author="Anthony Miyaguchi",
+    author_email="amiyaguchi@mozilla.com",
+    url="https://github.com/mozilla/python-libprio",
+    packages=["prio"],
     ext_modules=[extension_mod],
 )


### PR DESCRIPTION
This updates the README to address confusion around #34 due to the submodule. I've also added instructions for building `libprio` in macOS and modified the setup to automatically pull in the appropriate headers and libraries for each supported platform.

