### PR TITLE
Update submodule for simplified build and status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,10 @@ docker run -v `pwd`:/app -it prio bash
 ### Local
 
 Refer to the Dockerfile and the `libprio` submodule for dependencies. If you are
-running on macOS, you will need need to export the following flags for linking and
-including the necessary nss and nspr dependencies.
+running on macOS, the packages can be installed via homebrew.
 
 ```bash
 brew install nss nspr scons msgpack swig
-export LINKFLAGS="-L/usr/local/opt/nss/lib"
-export CPPFLAGS="-I/usr/local/opt/nss/include/nss -I/usr/local/opt/nspr/include/nspr"
 ```
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # python-libprio
-[![CircleCI](https://circleci.com/gh/acmiyaguchi/python-libprio.svg?style=svg)](https://circleci.com/gh/acmiyaguchi/python-libprio)
+[![CircleCI](https://circleci.com/gh/mozilla/python-libprio.svg?style=svg)](https://circleci.com/gh/mozilla/python-libprio)
 
 A python wrapper around libprio.
 


### PR DESCRIPTION
This updates the submodule to remove the linking dependencies. It also updates the status badge to point to the mozilla org. 