### PR TITLE
Fix memory allocation bug in msgpack reader

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,9 @@ jobs:
       - run:
           name: Test Code
           command: docker run prio
+      - run:
+          name: Integration Code
+          command: docker run prio scripts/test-cli-integration
 
 workflows:
     version: 2

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ RUN dnf install -y \
     swig \
     python3-devel \
     nss-devel \
-    msgpack-devel
+    msgpack-devel \
+    jq
 
 # symbolically link to name without version suffix to accomodate libprio includes
 RUN ln -s /usr/include/nspr4 /usr/include/nspr

--- a/libprio.i
+++ b/libprio.i
@@ -246,7 +246,9 @@ MSGPACK_WRITE(PrioTotalShare)
 SECStatus TYPE ## _read_wrapper(TYPE p, const unsigned char *data, unsigned int len, const_PrioConfig cfg) {
     SECStatus rv = SECFailure;
     msgpack_unpacker upk;
-    bool result = msgpack_unpacker_init(&upk, len+1);
+    // Allocate twice as much memory as our input buffer to prevent allocation
+    // errors in Linux.
+    bool result = msgpack_unpacker_init(&upk, len*2);
     if (result) {
         memcpy(msgpack_unpacker_buffer(&upk), data, len);
         msgpack_unpacker_buffer_consumed(&upk, len);

--- a/libprio.i
+++ b/libprio.i
@@ -17,7 +17,7 @@ atexit(Prio_clear);
 // Handle SECStatus.
 %typemap(out) SECStatus {
    if ($1 != SECSuccess) {
-       PyErr_SetString(PyExc_RuntimeError, "$symname was not succesful.");
+       PyErr_SetString(PyExc_RuntimeError, "$symname was not successful.");
        SWIG_fail;
    }
    $result = Py_BuildValue("");
@@ -239,6 +239,11 @@ MSGPACK_WRITE(PrioTotalShare)
     (const unsigned char *data, unsigned int len)
 }
 
+// Add a type-casting rule to prevent swig from adding the define into the scripting interface
+%inline %{
+#define MSGPACK_INIT_BUFFER_SIZE (size_t)128
+%}
+
 %define MSGPACK_READ(TYPE)
 %ignore TYPE ## _read;
 %rename(TYPE ## _read) TYPE ## _read_wrapper;
@@ -249,7 +254,7 @@ SECStatus TYPE ## _read_wrapper(TYPE p, const unsigned char *data, unsigned int 
     // Initialize the unpacker with a reasonably sized initial buffer. The
     // unpacker will eat into the initially reserved space for counting and may
     // need to be reallocated.
-    bool result = msgpack_unpacker_init(&upk, 128);
+    bool result = msgpack_unpacker_init(&upk, MSGPACK_INIT_BUFFER_SIZE);
     if (result) {
         if (msgpack_unpacker_buffer_capacity(&upk) < len) {
             result = msgpack_unpacker_reserve_buffer(&upk, len);
@@ -279,4 +284,4 @@ MSGPACK_READ(PrioTotalShare)
 // * http://www.swig.org/Doc3.0/SWIGDocumentation.html#Typemaps_nn2
 // * https://stackoverflow.com/questions/26567457/swig-wrapping-typedef-struct
 // * http://www.swig.org/Doc3.0/SWIGDocumentation.html#Typemaps_multi_argument_typemaps
-// * https://github.com/msgpack/msgpack-c/wiki/v1_1_c_overview
+// * https://github.com/msgpack/msgpack-c/wiki/v2_0_c_overview

--- a/libprio_wrap.c
+++ b/libprio_wrap.c
@@ -3196,13 +3196,19 @@ PyObject* PrioTotalShare_write_wrapper(const_PrioTotalShare p) {
 SECStatus PrioPacketVerify1_read_wrapper(PrioPacketVerify1 p, const unsigned char *data, unsigned int len, const_PrioConfig cfg) {
     SECStatus rv = SECFailure;
     msgpack_unpacker upk;
-    // Allocate twice as much memory as our input buffer to prevent allocation
-    // errors in Linux.
-    bool result = msgpack_unpacker_init(&upk, len*2);
+    // Initialize the unpacker with a reasonably sized initial buffer. The
+    // unpacker will eat into the initially reserved space for counting and may
+    // need to be reallocated.
+    bool result = msgpack_unpacker_init(&upk, 128);
     if (result) {
-        memcpy(msgpack_unpacker_buffer(&upk), data, len);
-        msgpack_unpacker_buffer_consumed(&upk, len);
-        rv = PrioPacketVerify1_read(p, &upk, cfg);
+        if (msgpack_unpacker_buffer_capacity(&upk) < len) {
+            result = msgpack_unpacker_reserve_buffer(&upk, len);
+        }
+        if (result) {
+            memcpy(msgpack_unpacker_buffer(&upk), data, len);
+            msgpack_unpacker_buffer_consumed(&upk, len);
+            rv = PrioPacketVerify1_read(p, &upk, cfg);
+        }
     }
     msgpack_unpacker_destroy(&upk);
     return rv;
@@ -3368,13 +3374,19 @@ SWIG_AsVal_unsigned_SS_int (PyObject * obj, unsigned int *val)
 SECStatus PrioPacketVerify2_read_wrapper(PrioPacketVerify2 p, const unsigned char *data, unsigned int len, const_PrioConfig cfg) {
     SECStatus rv = SECFailure;
     msgpack_unpacker upk;
-    // Allocate twice as much memory as our input buffer to prevent allocation
-    // errors in Linux.
-    bool result = msgpack_unpacker_init(&upk, len*2);
+    // Initialize the unpacker with a reasonably sized initial buffer. The
+    // unpacker will eat into the initially reserved space for counting and may
+    // need to be reallocated.
+    bool result = msgpack_unpacker_init(&upk, 128);
     if (result) {
-        memcpy(msgpack_unpacker_buffer(&upk), data, len);
-        msgpack_unpacker_buffer_consumed(&upk, len);
-        rv = PrioPacketVerify2_read(p, &upk, cfg);
+        if (msgpack_unpacker_buffer_capacity(&upk) < len) {
+            result = msgpack_unpacker_reserve_buffer(&upk, len);
+        }
+        if (result) {
+            memcpy(msgpack_unpacker_buffer(&upk), data, len);
+            msgpack_unpacker_buffer_consumed(&upk, len);
+            rv = PrioPacketVerify2_read(p, &upk, cfg);
+        }
     }
     msgpack_unpacker_destroy(&upk);
     return rv;
@@ -3384,13 +3396,19 @@ SECStatus PrioPacketVerify2_read_wrapper(PrioPacketVerify2 p, const unsigned cha
 SECStatus PrioTotalShare_read_wrapper(PrioTotalShare p, const unsigned char *data, unsigned int len, const_PrioConfig cfg) {
     SECStatus rv = SECFailure;
     msgpack_unpacker upk;
-    // Allocate twice as much memory as our input buffer to prevent allocation
-    // errors in Linux.
-    bool result = msgpack_unpacker_init(&upk, len*2);
+    // Initialize the unpacker with a reasonably sized initial buffer. The
+    // unpacker will eat into the initially reserved space for counting and may
+    // need to be reallocated.
+    bool result = msgpack_unpacker_init(&upk, 128);
     if (result) {
-        memcpy(msgpack_unpacker_buffer(&upk), data, len);
-        msgpack_unpacker_buffer_consumed(&upk, len);
-        rv = PrioTotalShare_read(p, &upk, cfg);
+        if (msgpack_unpacker_buffer_capacity(&upk) < len) {
+            result = msgpack_unpacker_reserve_buffer(&upk, len);
+        }
+        if (result) {
+            memcpy(msgpack_unpacker_buffer(&upk), data, len);
+            msgpack_unpacker_buffer_consumed(&upk, len);
+            rv = PrioTotalShare_read(p, &upk, cfg);
+        }
     }
     msgpack_unpacker_destroy(&upk);
     return rv;

--- a/libprio_wrap.c
+++ b/libprio_wrap.c
@@ -3193,13 +3193,16 @@ PyObject* PrioTotalShare_write_wrapper(const_PrioTotalShare p) {
 }
 
 
+#define MSGPACK_INIT_BUFFER_SIZE (size_t)128
+
+
 SECStatus PrioPacketVerify1_read_wrapper(PrioPacketVerify1 p, const unsigned char *data, unsigned int len, const_PrioConfig cfg) {
     SECStatus rv = SECFailure;
     msgpack_unpacker upk;
     // Initialize the unpacker with a reasonably sized initial buffer. The
     // unpacker will eat into the initially reserved space for counting and may
     // need to be reallocated.
-    bool result = msgpack_unpacker_init(&upk, 128);
+    bool result = msgpack_unpacker_init(&upk, MSGPACK_INIT_BUFFER_SIZE);
     if (result) {
         if (msgpack_unpacker_buffer_capacity(&upk) < len) {
             result = msgpack_unpacker_reserve_buffer(&upk, len);
@@ -3377,7 +3380,7 @@ SECStatus PrioPacketVerify2_read_wrapper(PrioPacketVerify2 p, const unsigned cha
     // Initialize the unpacker with a reasonably sized initial buffer. The
     // unpacker will eat into the initially reserved space for counting and may
     // need to be reallocated.
-    bool result = msgpack_unpacker_init(&upk, 128);
+    bool result = msgpack_unpacker_init(&upk, MSGPACK_INIT_BUFFER_SIZE);
     if (result) {
         if (msgpack_unpacker_buffer_capacity(&upk) < len) {
             result = msgpack_unpacker_reserve_buffer(&upk, len);
@@ -3399,7 +3402,7 @@ SECStatus PrioTotalShare_read_wrapper(PrioTotalShare p, const unsigned char *dat
     // Initialize the unpacker with a reasonably sized initial buffer. The
     // unpacker will eat into the initially reserved space for counting and may
     // need to be reallocated.
-    bool result = msgpack_unpacker_init(&upk, 128);
+    bool result = msgpack_unpacker_init(&upk, MSGPACK_INIT_BUFFER_SIZE);
     if (result) {
         if (msgpack_unpacker_buffer_capacity(&upk) < len) {
             result = msgpack_unpacker_reserve_buffer(&upk, len);
@@ -3638,7 +3641,7 @@ SWIGINTERN PyObject *_wrap_PrioPacketVerify1_read(PyObject *SWIGUNUSEDPARM(self)
   result = PrioPacketVerify1_read_wrapper(arg1,(unsigned char const *)arg2,arg3,(struct prio_config const *)arg4);
   {
     if (result != SECSuccess) {
-      PyErr_SetString(PyExc_RuntimeError, "PrioPacketVerify1_read was not succesful.");
+      PyErr_SetString(PyExc_RuntimeError, "PrioPacketVerify1_read was not successful.");
       SWIG_fail;
     }
     resultobj = Py_BuildValue("");
@@ -3678,7 +3681,7 @@ SWIGINTERN PyObject *_wrap_PrioPacketVerify2_read(PyObject *SWIGUNUSEDPARM(self)
   result = PrioPacketVerify2_read_wrapper(arg1,(unsigned char const *)arg2,arg3,(struct prio_config const *)arg4);
   {
     if (result != SECSuccess) {
-      PyErr_SetString(PyExc_RuntimeError, "PrioPacketVerify2_read was not succesful.");
+      PyErr_SetString(PyExc_RuntimeError, "PrioPacketVerify2_read was not successful.");
       SWIG_fail;
     }
     resultobj = Py_BuildValue("");
@@ -3718,7 +3721,7 @@ SWIGINTERN PyObject *_wrap_PrioTotalShare_read(PyObject *SWIGUNUSEDPARM(self), P
   result = PrioTotalShare_read_wrapper(arg1,(unsigned char const *)arg2,arg3,(struct prio_config const *)arg4);
   {
     if (result != SECSuccess) {
-      PyErr_SetString(PyExc_RuntimeError, "PrioTotalShare_read was not succesful.");
+      PyErr_SetString(PyExc_RuntimeError, "PrioTotalShare_read was not successful.");
       SWIG_fail;
     }
     resultobj = Py_BuildValue("");
@@ -3737,7 +3740,7 @@ SWIGINTERN PyObject *_wrap_Prio_init(PyObject *SWIGUNUSEDPARM(self), PyObject *a
   result = Prio_init();
   {
     if (result != SECSuccess) {
-      PyErr_SetString(PyExc_RuntimeError, "Prio_init was not succesful.");
+      PyErr_SetString(PyExc_RuntimeError, "Prio_init was not successful.");
       SWIG_fail;
     }
     resultobj = Py_BuildValue("");
@@ -3878,7 +3881,7 @@ SWIGINTERN PyObject *_wrap_Keypair_new(PyObject *SWIGUNUSEDPARM(self), PyObject 
   result = Keypair_new(arg1,arg2);
   {
     if (result != SECSuccess) {
-      PyErr_SetString(PyExc_RuntimeError, "Keypair_new was not succesful.");
+      PyErr_SetString(PyExc_RuntimeError, "Keypair_new was not successful.");
       SWIG_fail;
     }
     resultobj = Py_BuildValue("");
@@ -3919,7 +3922,7 @@ SWIGINTERN PyObject *_wrap_PublicKey_import(PyObject *SWIGUNUSEDPARM(self), PyOb
   result = PublicKey_import(arg1,(unsigned char const *)arg2,arg3);
   {
     if (result != SECSuccess) {
-      PyErr_SetString(PyExc_RuntimeError, "PublicKey_import was not succesful.");
+      PyErr_SetString(PyExc_RuntimeError, "PublicKey_import was not successful.");
       SWIG_fail;
     }
     resultobj = Py_BuildValue("");
@@ -3968,7 +3971,7 @@ SWIGINTERN PyObject *_wrap_PrivateKey_import(PyObject *SWIGUNUSEDPARM(self), PyO
   result = PrivateKey_import(arg1,(unsigned char const *)arg2,arg3,(unsigned char const *)arg4,arg5);
   {
     if (result != SECSuccess) {
-      PyErr_SetString(PyExc_RuntimeError, "PrivateKey_import was not succesful.");
+      PyErr_SetString(PyExc_RuntimeError, "PrivateKey_import was not successful.");
       SWIG_fail;
     }
     resultobj = Py_BuildValue("");
@@ -4006,7 +4009,7 @@ SWIGINTERN PyObject *_wrap_PublicKey_import_hex(PyObject *SWIGUNUSEDPARM(self), 
   result = PublicKey_import_hex(arg1,(unsigned char const *)arg2,arg3);
   {
     if (result != SECSuccess) {
-      PyErr_SetString(PyExc_RuntimeError, "PublicKey_import_hex was not succesful.");
+      PyErr_SetString(PyExc_RuntimeError, "PublicKey_import_hex was not successful.");
       SWIG_fail;
     }
     resultobj = Py_BuildValue("");
@@ -4055,7 +4058,7 @@ SWIGINTERN PyObject *_wrap_PrivateKey_import_hex(PyObject *SWIGUNUSEDPARM(self),
   result = PrivateKey_import_hex(arg1,(unsigned char const *)arg2,arg3,(unsigned char const *)arg4,arg5);
   {
     if (result != SECSuccess) {
-      PyErr_SetString(PyExc_RuntimeError, "PrivateKey_import_hex was not succesful.");
+      PyErr_SetString(PyExc_RuntimeError, "PrivateKey_import_hex was not successful.");
       SWIG_fail;
     }
     resultobj = Py_BuildValue("");
@@ -4107,7 +4110,7 @@ SWIGINTERN PyObject *_wrap_PrioClient_encode(PyObject *SWIGUNUSEDPARM(self), PyO
   result = PrioClient_encode((struct prio_config const *)arg1,(bool const *)arg2,arg3,arg4,arg5,arg6);
   {
     if (result != SECSuccess) {
-      PyErr_SetString(PyExc_RuntimeError, "PrioClient_encode was not succesful.");
+      PyErr_SetString(PyExc_RuntimeError, "PrioClient_encode was not successful.");
       SWIG_fail;
     }
     resultobj = Py_BuildValue("");
@@ -4143,7 +4146,7 @@ SWIGINTERN PyObject *_wrap_PrioPRGSeed_randomize(PyObject *SWIGUNUSEDPARM(self),
   result = PrioPRGSeed_randomize((unsigned char (*)[AES_128_KEY_LENGTH])arg1);
   {
     if (result != SECSuccess) {
-      PyErr_SetString(PyExc_RuntimeError, "PrioPRGSeed_randomize was not succesful.");
+      PyErr_SetString(PyExc_RuntimeError, "PrioPRGSeed_randomize was not successful.");
       SWIG_fail;
     }
     resultobj = Py_BuildValue("");
@@ -4240,7 +4243,7 @@ SWIGINTERN PyObject *_wrap_PrioVerifier_set_data(PyObject *SWIGUNUSEDPARM(self),
   result = PrioVerifier_set_data(arg1,arg2,arg3);
   {
     if (result != SECSuccess) {
-      PyErr_SetString(PyExc_RuntimeError, "PrioVerifier_set_data was not succesful.");
+      PyErr_SetString(PyExc_RuntimeError, "PrioVerifier_set_data was not successful.");
       SWIG_fail;
     }
     resultobj = Py_BuildValue("");
@@ -4284,7 +4287,7 @@ SWIGINTERN PyObject *_wrap_PrioPacketVerify1_set_data(PyObject *SWIGUNUSEDPARM(s
   result = PrioPacketVerify1_set_data(arg1,(struct prio_verifier const *)arg2);
   {
     if (result != SECSuccess) {
-      PyErr_SetString(PyExc_RuntimeError, "PrioPacketVerify1_set_data was not succesful.");
+      PyErr_SetString(PyExc_RuntimeError, "PrioPacketVerify1_set_data was not successful.");
       SWIG_fail;
     }
     resultobj = Py_BuildValue("");
@@ -4338,7 +4341,7 @@ SWIGINTERN PyObject *_wrap_PrioPacketVerify2_set_data(PyObject *SWIGUNUSEDPARM(s
   result = PrioPacketVerify2_set_data(arg1,(struct prio_verifier const *)arg2,(struct prio_packet_verify1 const *)arg3,(struct prio_packet_verify1 const *)arg4);
   {
     if (result != SECSuccess) {
-      PyErr_SetString(PyExc_RuntimeError, "PrioPacketVerify2_set_data was not succesful.");
+      PyErr_SetString(PyExc_RuntimeError, "PrioPacketVerify2_set_data was not successful.");
       SWIG_fail;
     }
     resultobj = Py_BuildValue("");
@@ -4372,7 +4375,7 @@ SWIGINTERN PyObject *_wrap_PrioVerifier_isValid(PyObject *SWIGUNUSEDPARM(self), 
   result = PrioVerifier_isValid((struct prio_verifier const *)arg1,(struct prio_packet_verify2 const *)arg2,(struct prio_packet_verify2 const *)arg3);
   {
     if (result != SECSuccess) {
-      PyErr_SetString(PyExc_RuntimeError, "PrioVerifier_isValid was not succesful.");
+      PyErr_SetString(PyExc_RuntimeError, "PrioVerifier_isValid was not successful.");
       SWIG_fail;
     }
     resultobj = Py_BuildValue("");
@@ -4401,7 +4404,7 @@ SWIGINTERN PyObject *_wrap_PrioServer_aggregate(PyObject *SWIGUNUSEDPARM(self), 
   result = PrioServer_aggregate(arg1,arg2);
   {
     if (result != SECSuccess) {
-      PyErr_SetString(PyExc_RuntimeError, "PrioServer_aggregate was not succesful.");
+      PyErr_SetString(PyExc_RuntimeError, "PrioServer_aggregate was not successful.");
       SWIG_fail;
     }
     resultobj = Py_BuildValue("");
@@ -4445,7 +4448,7 @@ SWIGINTERN PyObject *_wrap_PrioTotalShare_set_data(PyObject *SWIGUNUSEDPARM(self
   result = PrioTotalShare_set_data(arg1,(struct prio_server const *)arg2);
   {
     if (result != SECSuccess) {
-      PyErr_SetString(PyExc_RuntimeError, "PrioTotalShare_set_data was not succesful.");
+      PyErr_SetString(PyExc_RuntimeError, "PrioTotalShare_set_data was not successful.");
       SWIG_fail;
     }
     resultobj = Py_BuildValue("");
@@ -4481,7 +4484,7 @@ SWIGINTERN PyObject *_wrap_PrioTotalShare_final(PyObject *SWIGUNUSEDPARM(self), 
   result = PrioTotalShare_final((struct prio_config const *)arg1,arg2,(struct prio_total_share const *)arg3,(struct prio_total_share const *)arg4);
   {
     if (result != SECSuccess) {
-      PyErr_SetString(PyExc_RuntimeError, "PrioTotalShare_final was not succesful.");
+      PyErr_SetString(PyExc_RuntimeError, "PrioTotalShare_final was not successful.");
       SWIG_fail;
     }
     resultobj = Py_BuildValue("");

--- a/libprio_wrap.c
+++ b/libprio_wrap.c
@@ -3196,7 +3196,9 @@ PyObject* PrioTotalShare_write_wrapper(const_PrioTotalShare p) {
 SECStatus PrioPacketVerify1_read_wrapper(PrioPacketVerify1 p, const unsigned char *data, unsigned int len, const_PrioConfig cfg) {
     SECStatus rv = SECFailure;
     msgpack_unpacker upk;
-    bool result = msgpack_unpacker_init(&upk, len+1);
+    // Allocate twice as much memory as our input buffer to prevent allocation
+    // errors in Linux.
+    bool result = msgpack_unpacker_init(&upk, len*2);
     if (result) {
         memcpy(msgpack_unpacker_buffer(&upk), data, len);
         msgpack_unpacker_buffer_consumed(&upk, len);
@@ -3366,7 +3368,9 @@ SWIG_AsVal_unsigned_SS_int (PyObject * obj, unsigned int *val)
 SECStatus PrioPacketVerify2_read_wrapper(PrioPacketVerify2 p, const unsigned char *data, unsigned int len, const_PrioConfig cfg) {
     SECStatus rv = SECFailure;
     msgpack_unpacker upk;
-    bool result = msgpack_unpacker_init(&upk, len+1);
+    // Allocate twice as much memory as our input buffer to prevent allocation
+    // errors in Linux.
+    bool result = msgpack_unpacker_init(&upk, len*2);
     if (result) {
         memcpy(msgpack_unpacker_buffer(&upk), data, len);
         msgpack_unpacker_buffer_consumed(&upk, len);
@@ -3380,7 +3384,9 @@ SECStatus PrioPacketVerify2_read_wrapper(PrioPacketVerify2 p, const unsigned cha
 SECStatus PrioTotalShare_read_wrapper(PrioTotalShare p, const unsigned char *data, unsigned int len, const_PrioConfig cfg) {
     SECStatus rv = SECFailure;
     msgpack_unpacker upk;
-    bool result = msgpack_unpacker_init(&upk, len+1);
+    // Allocate twice as much memory as our input buffer to prevent allocation
+    // errors in Linux.
+    bool result = msgpack_unpacker_init(&upk, len*2);
     if (result) {
         memcpy(msgpack_unpacker_buffer(&upk), data, len);
         msgpack_unpacker_buffer_consumed(&upk, len);

--- a/scripts/test-cli-integration
+++ b/scripts/test-cli-integration
@@ -4,6 +4,7 @@ set -eou pipefail
 set -x
 
 cd "$(dirname "$0")/.."
+scripts/create-folder
 
 key_a=$(prio keygen)
 key_b=$(prio keygen)

--- a/scripts/test-cli-integration
+++ b/scripts/test-cli-integration
@@ -37,7 +37,7 @@ EOF
 
 jq -c '.' ${CLIENT_BUCKET}/data.ndjson
 
-python -m prio encode-shares \
+python3 -m prio encode-shares \
     --n-data ${N_DATA} \
     --batch-id ${BATCH_ID} \
     --public-key-hex-internal ${SERVER_A_PUBLIC_KEY} \
@@ -53,7 +53,7 @@ jq -c '.' ${SERVER_B_BUCKET}/raw/data.ndjson
 # verify1
 ###########################################################
 
-python -m prio verify1 \
+python3 -m prio verify1 \
     --n-data ${N_DATA} \
     --batch-id ${BATCH_ID} \
     --server-id A \
@@ -70,7 +70,7 @@ cp \
     ${SERVER_A_BUCKET}/intermediate/internal/verify1/data.ndjson \
     ${SERVER_B_BUCKET}/intermediate/external/verify1/
 
-python -m prio verify1 \
+python3 -m prio verify1 \
     --n-data ${N_DATA} \
     --batch-id ${BATCH_ID} \
     --server-id B \
@@ -91,7 +91,7 @@ cp \
 # verify2
 ###########################################################
 
-python -m prio verify2 \
+python3 -m prio verify2 \
     --n-data ${N_DATA} \
     --batch-id ${BATCH_ID} \
     --server-id A \
@@ -110,7 +110,7 @@ cp \
     ${SERVER_A_BUCKET}/intermediate/internal/verify2/data.ndjson \
     ${SERVER_B_BUCKET}/intermediate/external/verify2/
 
-python -m prio verify2 \
+python3 -m prio verify2 \
     --n-data ${N_DATA} \
     --batch-id ${BATCH_ID} \
     --server-id B \
@@ -133,7 +133,7 @@ cp \
 # aggregate
 ###########################################################
 
-python -m prio aggregate \
+python3 -m prio aggregate \
     --n-data ${N_DATA} \
     --batch-id ${BATCH_ID} \
     --server-id A \
@@ -152,7 +152,7 @@ cp \
     ${SERVER_A_BUCKET}/intermediate/internal/aggregate/data.ndjson \
     ${SERVER_B_BUCKET}/intermediate/external/aggregate/
 
-python -m prio aggregate \
+python3 -m prio aggregate \
     --n-data ${N_DATA} \
     --batch-id ${BATCH_ID} \
     --server-id B \
@@ -175,7 +175,7 @@ cp \
 # publish
 ###########################################################
 
-python -m prio publish \
+python3 -m prio publish \
     --n-data ${N_DATA} \
     --batch-id ${BATCH_ID} \
     --server-id A \
@@ -189,7 +189,7 @@ python -m prio publish \
 
 jq -c '.' ${SERVER_A_BUCKET}/processed/data.ndjson
 
-python -m prio publish \
+python3 -m prio publish \
     --n-data ${N_DATA} \
     --batch-id ${BATCH_ID} \
     --server-id B \


### PR DESCRIPTION
This fixes a bug with the `test-cli-integration` script in Linux by allocating more memory to the msgpack unpacker before reading data into libprio data-structures.

