### PR TITLE
Update tag for deploying to dockerhub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,12 +82,12 @@ jobs:
             echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
             # deploy master
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
-              docker tag app:build ${DOCKERHUB_REPO}:latest
+              docker tag prio:prod ${DOCKERHUB_REPO}:latest
               docker push ${DOCKERHUB_REPO}:latest
             elif  [ ! -z "${CIRCLE_TAG}" ]; then
             # deploy a release tag...
               echo "${DOCKERHUB_REPO}:${CIRCLE_TAG}"
-              docker tag app:build "${DOCKERHUB_REPO}:${CIRCLE_TAG}"
+              docker tag prio:prod "${DOCKERHUB_REPO}:${CIRCLE_TAG}"
               docker images
               docker push "${DOCKERHUB_REPO}:${CIRCLE_TAG}"
             fi


### PR DESCRIPTION
```bash
#!/bin/sh -eo pipefail
echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
# deploy master
if [ "${CIRCLE_BRANCH}" == "master" ]; then
  docker tag app:build ${DOCKERHUB_REPO}:latest
  docker push ${DOCKERHUB_REPO}:latest
elif  [ ! -z "${CIRCLE_TAG}" ]; then
# deploy a release tag...
  echo "${DOCKERHUB_REPO}:${CIRCLE_TAG}"
  docker tag app:build "${DOCKERHUB_REPO}:${CIRCLE_TAG}"
  docker images
  docker push "${DOCKERHUB_REPO}:${CIRCLE_TAG}"
fi

WARNING! Your password will be stored unencrypted in /root/.docker/config.json.
Configure a credential helper to remove this warning. See
https://docs.docker.com/engine/reference/commandline/login/#credentials-store

Login Succeeded
Error response from daemon: No such image: app:build
Exited with code 1
```